### PR TITLE
Use kcp-go fork

### DIFF
--- a/config.go
+++ b/config.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/getlantern/golog"
-	kcp "github.com/xtaci/kcp-go"
+	kcp "github.com/getlantern/kcp-go"
 	"golang.org/x/crypto/pbkdf2"
 )
 

--- a/dialer.go
+++ b/dialer.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/getlantern/cmux"
 	"github.com/getlantern/errors"
-	"github.com/xtaci/kcp-go"
+	"github.com/getlantern/kcp-go"
 )
 
 // DialerConfig configures dialing

--- a/listener.go
+++ b/listener.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/getlantern/cmux"
-	"github.com/xtaci/kcp-go"
+	"github.com/getlantern/kcp-go"
 )
 
 // ListenerConfig configures listening


### PR DESCRIPTION
Updates kcpwrapper to use our kcp-go fork which uses `netx.DialUDP`